### PR TITLE
Get Elixir to work on Trusty

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,16 @@
 sudo: required
-
-language: elixir
+dist: trusty
+language: erlang
 
 services:
   - docker
+
 before_install:
-  - docker run -d --name=s3rver -p 127.0.0.1:4568:4568 -t triplew/s3rver
+- wget https://packages.erlang-solutions.com/erlang-solutions_1.0_all.deb && sudo dpkg -i erlang-solutions_1.0_all.deb
+- sudo apt-get update
+- sudo apt-get install -y esl-erlang
+- sudo apt-get install -y elixir
+- docker run -d --name=s3rver -p 127.0.0.1:4568:4568 -t triplew/s3rver
 
 script:
   - mix test


### PR DESCRIPTION
This will manually install Elixir without kiex on Travis's Trusty/GCE builds. The current erlang image for Trusty/GCE is missing kiex. (And you must be on the Trusty infrastructure for Docker support).
